### PR TITLE
修正 RTP 安裝邏輯：跳過會覆蓋原版 .xyz 的 .png 文件

### DIFF
--- a/core/external/rtp.py
+++ b/core/external/rtp.py
@@ -253,6 +253,15 @@ def install_rtp_files(target_game_dir, selected_rtp_zips):
                         rtp_skipped += 1
                         continue
 
+                    # EasyRPG prioritises .png over .xyz when both share the same base name.
+                    # Skip installing a .png RTP file if the game already has the .xyz variant,
+                    # so the original game graphics are not shadowed.
+                    if destination_path.lower().endswith('.png'):
+                        xyz_counterpart = destination_path[:-4] + '.xyz'
+                        if os.path.exists(xyz_counterpart):
+                            rtp_skipped += 1
+                            continue
+
                     try:
                         with zip_ref.open(info, "r") as src, open(destination_path, "wb") as dst:
                             shutil.copyfileobj(src, dst)


### PR DESCRIPTION
EasyRPG 遇到同名 .png 與 .xyz 時優先讀取 .png，
導致 RTP 的 .png 遮蓋遊戲原版 .xyz 圖形資源。
安裝時若目標目錄已有同底名的 .xyz，則跳過該 .png RTP 文件。

## Summary by Sourcery

错误修复：
- 当游戏中已经包含具有相同基础文件名的 `.xyz` 文件时，跳过安装 RTP 的 `.png` 文件，以避免 EasyRPG 将 RTP 图像优先于原始游戏资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Skip installing RTP .png files when a game already contains .xyz files with the same base name to avoid EasyRPG prioritising RTP graphics over original game assets.

</details>