### PR TITLE
新增 RM2K/RM2K3 地圖名稱匯出與匯入功能

### DIFF
--- a/core/engines/rm2k.py
+++ b/core/engines/rm2k.py
@@ -40,7 +40,12 @@ _DETECT_CANDIDATES = ["cp932", "gbk", "big5", "cp1252", "utf-8"]
 
 
 def _codec(code: str) -> str:
-    return _CODE_TO_CODEC.get(str(code), "cp932")
+    import codecs
+    try:
+        codecs.lookup(code)
+        return code  # already a valid codec name (e.g. "big5" from auto_detect_encoding)
+    except LookupError:
+        return _CODE_TO_CODEC.get(str(code), "cp932")
 
 
 def auto_detect_encoding(game_path: str) -> str:

--- a/core/engines/rm2k.py
+++ b/core/engines/rm2k.py
@@ -59,7 +59,8 @@ def auto_detect_encoding(game_path: str) -> str:
         return "cp932"
 
     try:
-        _, entries, _ = _read_lmt(open(lmt_path, "rb").read())
+        with open(lmt_path, "rb") as f:
+            _, entries, _ = _read_lmt(f.read())
         sample: List[bytes] = []
         for eid, fields in entries:
             if eid == 0:
@@ -239,7 +240,8 @@ def export_names(game_path: str, encoding_code: str, message_queue=None) -> bool
         return True
 
     try:
-        _, lmt_entries, _ = _read_lmt(open(lmt_path, "rb").read())
+        with open(lmt_path, "rb") as f:
+            _, lmt_entries, _ = _read_lmt(f.read())
         names: Dict[int, str] = {}
         for eid, fields in lmt_entries:
             if eid == 0:
@@ -279,9 +281,8 @@ def import_names(game_path: str, encoding_code: str, message_queue=None) -> bool
         return True
 
     try:
-        translations = _parse_mapnames_file(
-            open(names_path, "r", encoding="utf-8-sig").read()
-        )
+        with open(names_path, "r", encoding="utf-8-sig") as f:
+            translations = _parse_mapnames_file(f.read())
     except Exception as e:
         _log("error", f"  [RM2K] 讀取地圖名稱文件失敗: {e}")
         return False
@@ -295,7 +296,8 @@ def import_names(game_path: str, encoding_code: str, message_queue=None) -> bool
         return False
 
     try:
-        magic, entries, lmt_tail = _read_lmt(open(lmt_path, "rb").read())
+        with open(lmt_path, "rb") as f:
+            magic, entries, lmt_tail = _read_lmt(f.read())
         new_entries = []
         count = 0
         for eid, fields in entries:

--- a/core/engines/rm2k.py
+++ b/core/engines/rm2k.py
@@ -1,0 +1,323 @@
+"""
+RPG Maker 2000/2003 (RM2k/RM2k3) map name support.
+
+Exports and re-imports map names from the LCF binary file RPG_RT.lmt.
+Map names are shown in teleport skills, so translating them lets players
+know which locations they can travel to.
+
+Export writes  StringScripts/RM2K_MapNames.txt  (UTF-8).
+Import reads that file and patches RPG_RT.lmt in-place (with .bak backup).
+"""
+
+import logging
+import os
+import shutil
+from typing import Dict, List, Optional, Tuple
+
+log = logging.getLogger(__name__)
+
+STRING_SCRIPTS_DIRNAME = "StringScripts"
+RM2K_MAPNAMES_FILENAME = "RM2K_MapNames.txt"
+
+FIELD_NAME = 0x01
+
+_ENTRY_SEP = "*" * 5
+_ID_SEP    = "-" * 5
+SEC_MAP_NAMES = "RM2K_MapNames"
+
+_CODE_TO_CODEC: Dict[str, str] = {
+    "932":   "cp932",
+    "936":   "gbk",
+    "950":   "big5",
+    "1252":  "cp1252",
+    "1251":  "cp1251",
+    "1250":  "cp1250",
+    "65001": "utf-8",
+    "0":     "cp932",
+}
+
+_DETECT_CANDIDATES = ["cp932", "gbk", "big5", "cp1252", "utf-8"]
+
+
+def _codec(code: str) -> str:
+    return _CODE_TO_CODEC.get(str(code), "cp932")
+
+
+def auto_detect_encoding(game_path: str) -> str:
+    """Sniff the source encoding of RPG_RT.lmt by scoring map name bytes.
+
+    Tries candidate codecs and picks the one with the fewest replacement
+    characters.  Falls back to cp932 if nothing conclusive is found.
+    """
+    lmt_path = os.path.join(game_path, "RPG_RT.lmt")
+    if not os.path.isfile(lmt_path):
+        return "cp932"
+
+    try:
+        _, entries, _ = _read_lmt(open(lmt_path, "rb").read())
+        sample: List[bytes] = []
+        for eid, fields in entries:
+            if eid == 0:
+                continue
+            nb = fields.get(FIELD_NAME, b"")
+            if nb:
+                sample.append(nb)
+
+        if not sample:
+            return "cp932"
+
+        combined = b" ".join(sample)
+        best_enc, best_score = "cp932", -1
+        for enc in _DETECT_CANDIDATES:
+            try:
+                decoded = combined.decode(enc, errors="replace")
+                score = decoded.count("�")
+                if score < best_score or best_score == -1:
+                    best_score = score
+                    best_enc = enc
+            except (LookupError, UnicodeDecodeError):
+                continue
+
+        log.info(f"[RM2K] 自動偵測編碼: {best_enc} (替換字元數: {best_score})")
+        return best_enc
+
+    except Exception as e:
+        log.warning(f"[RM2K] 編碼偵測失敗，使用預設 cp932: {e}")
+        return "cp932"
+
+
+# ── BER codec ────────────────────────────────────────────────────────────────
+
+def _read_ber(data: bytes, pos: int) -> Tuple[int, int]:
+    value = 0
+    while pos < len(data):
+        b = data[pos]; pos += 1
+        value = (value << 7) | (b & 0x7F)
+        if not (b & 0x80):
+            break
+    return value, pos
+
+
+def _write_ber(n: int) -> bytes:
+    if n == 0:
+        return b"\x00"
+    parts: List[int] = []
+    while n:
+        parts.append(n & 0x7F)
+        n >>= 7
+    parts.reverse()
+    for i in range(len(parts) - 1):
+        parts[i] |= 0x80
+    return bytes(parts)
+
+
+# ── Generic flat-array parser/serialiser ─────────────────────────────────────
+
+def _parse_array_end(data: bytes, pos: int = 0) -> Tuple[List[Tuple[int, Dict[int, bytes]]], int]:
+    count, pos = _read_ber(data, pos)
+    entries: List[Tuple[int, Dict[int, bytes]]] = []
+    for _ in range(count):
+        if pos >= len(data):
+            break
+        eid, pos = _read_ber(data, pos)
+        fields: Dict[int, bytes] = {}
+        while pos < len(data):
+            fk, pos = _read_ber(data, pos)
+            if fk == 0:
+                break
+            fs, pos = _read_ber(data, pos)
+            fields[fk] = data[pos: pos + fs]
+            pos += fs
+        entries.append((eid, fields))
+    return entries, pos
+
+
+def _serialise_array(entries: List[Tuple[int, Dict[int, bytes]]]) -> bytes:
+    out = bytearray(_write_ber(len(entries)))
+    for eid, fields in entries:
+        out += _write_ber(eid)
+        for fk in sorted(fields.keys()):
+            fdata = fields[fk]
+            out += _write_ber(fk)
+            out += _write_ber(len(fdata))
+            out += fdata
+        out += b"\x00"
+    return bytes(out)
+
+
+# ── LMT helpers ──────────────────────────────────────────────────────────────
+
+def _read_lmt(data: bytes) -> Tuple[bytes, List[Tuple[int, Dict[int, bytes]]], bytes]:
+    """Return (magic_bytes, node_entries, tail_bytes).
+
+    tail_bytes holds everything after the node array (starting location,
+    active_node, vehicle positions, etc.) and must be written back verbatim.
+    """
+    ml, pos = _read_ber(data, 0)
+    magic = data[pos: pos + ml]
+    pos += ml
+    entries, end_pos = _parse_array_end(data, pos)
+    tail = data[end_pos:]
+    return magic, entries, tail
+
+
+def _write_lmt(magic: bytes, entries: List[Tuple[int, Dict[int, bytes]]],
+               tail: bytes = b"") -> bytes:
+    out = bytearray(_write_ber(len(magic)))
+    out += magic
+    out += _serialise_array(entries)
+    out += tail
+    return bytes(out)
+
+
+# ── StringScripts format ─────────────────────────────────────────────────────
+
+def _write_mapnames_file(names: Dict[int, str]) -> str:
+    lines: List[str] = []
+    lines.append(f"{_ENTRY_SEP}{SEC_MAP_NAMES}{_ENTRY_SEP}")
+    for eid in sorted(names.keys()):
+        lines.append(f"{_ID_SEP}{eid}{_ID_SEP}")
+        lines.append(names[eid])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _parse_mapnames_file(content: str) -> Dict[int, str]:
+    result: Dict[int, str] = {}
+    in_section = False
+    current_id: Optional[int] = None
+    pending_lines: List[str] = []
+
+    def _flush():
+        if current_id is not None:
+            result[current_id] = "\n".join(pending_lines).rstrip("\n")
+
+    for raw in content.splitlines():
+        if raw.startswith(_ENTRY_SEP) and raw.endswith(_ENTRY_SEP) and len(raw) > 10:
+            _flush()
+            pending_lines.clear()
+            current_id = None
+            in_section = (raw.strip("*").strip() == SEC_MAP_NAMES)
+            continue
+        if not in_section:
+            continue
+        if raw.startswith(_ID_SEP) and raw.endswith(_ID_SEP) and len(raw) > 10:
+            _flush()
+            pending_lines.clear()
+            try:
+                current_id = int(raw.strip("-").strip())
+            except ValueError:
+                current_id = None
+            continue
+        if current_id is not None:
+            pending_lines.append(raw)
+
+    _flush()
+    return result
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+def export_names(game_path: str, encoding_code: str, message_queue=None) -> bool:
+    """Export map names from RPG_RT.lmt to StringScripts/RM2K_MapNames.txt."""
+    def _log(level: str, msg: str):
+        log.info(msg)
+        if message_queue:
+            message_queue.put(("log", (level, msg)))
+
+    enc = _codec(encoding_code)
+    lmt_path = os.path.join(game_path, "RPG_RT.lmt")
+    ss_dir   = os.path.join(game_path, STRING_SCRIPTS_DIRNAME)
+    os.makedirs(ss_dir, exist_ok=True)
+
+    if not os.path.isfile(lmt_path):
+        return True
+
+    try:
+        _, lmt_entries, _ = _read_lmt(open(lmt_path, "rb").read())
+        names: Dict[int, str] = {}
+        for eid, fields in lmt_entries:
+            if eid == 0:
+                continue
+            raw = fields.get(FIELD_NAME, b"")
+            if raw:
+                names[eid] = raw.decode(enc, errors="replace")
+        _log("normal", f"  [RM2K] 地圖名稱: {len(names)} 個")
+    except Exception as e:
+        _log("warning", f"  [RM2K] 解析 RPG_RT.lmt 失敗: {e}")
+        return False
+
+    out_path = os.path.join(ss_dir, RM2K_MAPNAMES_FILENAME)
+    try:
+        with open(out_path, "w", encoding="utf-8") as f:
+            f.write(_write_mapnames_file(names))
+        _log("success", f"  [RM2K] 已寫入 {RM2K_MAPNAMES_FILENAME}，共 {len(names)} 個地圖名稱")
+        return True
+    except Exception as e:
+        _log("error", f"  [RM2K] 寫入地圖名稱失敗: {e}")
+        return False
+
+
+def import_names(game_path: str, encoding_code: str, message_queue=None) -> bool:
+    """Import translated map names from StringScripts/RM2K_MapNames.txt into RPG_RT.lmt."""
+    def _log(level: str, msg: str):
+        log.info(msg)
+        if message_queue:
+            message_queue.put(("log", (level, msg)))
+
+    enc        = _codec(encoding_code)
+    lmt_path   = os.path.join(game_path, "RPG_RT.lmt")
+    names_path = os.path.join(game_path, STRING_SCRIPTS_DIRNAME, RM2K_MAPNAMES_FILENAME)
+
+    if not os.path.isfile(names_path):
+        _log("normal", f"  [RM2K] 未找到 {RM2K_MAPNAMES_FILENAME}，跳過地圖名稱導入")
+        return True
+
+    try:
+        translations = _parse_mapnames_file(
+            open(names_path, "r", encoding="utf-8-sig").read()
+        )
+    except Exception as e:
+        _log("error", f"  [RM2K] 讀取地圖名稱文件失敗: {e}")
+        return False
+
+    if not translations:
+        _log("normal", "  [RM2K] 地圖名稱文件無可導入內容")
+        return True
+
+    if not os.path.isfile(lmt_path):
+        _log("error", f"  [RM2K] 未找到 RPG_RT.lmt: {lmt_path}")
+        return False
+
+    try:
+        magic, entries, lmt_tail = _read_lmt(open(lmt_path, "rb").read())
+        new_entries = []
+        count = 0
+        for eid, fields in entries:
+            if eid in translations:
+                try:
+                    nb = translations[eid].encode(enc, errors="strict")
+                    fields = dict(fields)
+                    fields[FIELD_NAME] = nb
+                    count += 1
+                except (UnicodeEncodeError, LookupError):
+                    _log("warning", f"  [RM2K] 無法將 map {eid} 名稱編碼為 {enc}，保留原文")
+            new_entries.append((eid, fields))
+
+        if count == 0:
+            _log("normal", "  [RM2K] LMT: 無符合的地圖名稱需要更新")
+            return True
+
+        bak = lmt_path + ".bak"
+        if not os.path.exists(bak):
+            shutil.copy2(lmt_path, bak)
+            _log("normal", "  [RM2K] 已備份 RPG_RT.lmt → .bak")
+
+        with open(lmt_path, "wb") as f:
+            f.write(_write_lmt(magic, new_entries, lmt_tail))
+        _log("success", f"  [RM2K] RPG_RT.lmt: 已更新 {count} 個地圖名稱")
+        return True
+
+    except Exception as e:
+        _log("error", f"  [RM2K] 更新 RPG_RT.lmt 失敗: {e}")
+        return False

--- a/core/tasks/export.py
+++ b/core/tasks/export.py
@@ -160,8 +160,9 @@ def run_export(game_path, export_encoding, message_queue):
                 # --- 导出 RM2K 地图名称 ---
                 try:
                     from core.engines import rm2k
-                    message_queue.put(("log", ("normal", "正在导出 RM2K 地图名称...")))
-                    rm2k.export_names(game_path, export_encoding, message_queue)
+                    src_enc = rm2k.auto_detect_encoding(game_path)
+                    message_queue.put(("log", ("normal", f"正在导出 RM2K 地图名称（偵測來源編碼: {src_enc}）...")))
+                    rm2k.export_names(game_path, src_enc, message_queue)
                 except Exception as rm2k_err:
                     log.exception("导出 RM2K 地图名称时发生错误。")
                     message_queue.put(("warning", f"导出 RM2K 地图名称失败（不影响主要导出结果）: {rm2k_err}"))

--- a/core/tasks/export.py
+++ b/core/tasks/export.py
@@ -157,6 +157,16 @@ def run_export(game_path, export_encoding, message_queue):
         if export_successful:
             if os.path.exists(string_scripts_path):
 
+                # --- 导出 RM2K 地图名称 ---
+                try:
+                    from core.engines import rm2k
+                    message_queue.put(("log", ("normal", "正在导出 RM2K 地图名称...")))
+                    rm2k.export_names(game_path, export_encoding, message_queue)
+                except Exception as rm2k_err:
+                    log.exception("导出 RM2K 地图名称时发生错误。")
+                    message_queue.put(("warning", f"导出 RM2K 地图名称失败（不影响主要导出结果）: {rm2k_err}"))
+                # -----------------------------------------
+
                 # --- 新增：备份 StringScripts 到 StringScripts_Origin ---
                 try:
                     message_queue.put(("log", ("normal", "正在备份原始 StringScripts 到 StringScripts_Origin...")))

--- a/core/tasks/import_task.py
+++ b/core/tasks/import_task.py
@@ -74,6 +74,17 @@ def run_import(game_path, import_encoding, message_queue):
 
         if return_code == 0:
             message_queue.put(("log", ("success", "RPGRewriter 导入命令成功完成。")))
+
+            # --- 导入 RM2K 地图名称 ---
+            try:
+                from core.engines import rm2k
+                message_queue.put(("log", ("normal", "正在导入 RM2K 地图名称...")))
+                rm2k.import_names(game_path, import_encoding, message_queue)
+            except Exception as rm2k_err:
+                log.exception("导入 RM2K 地图名称时发生错误。")
+                message_queue.put(("warning", f"导入 RM2K 地图名称失败（不影响主要导入结果）: {rm2k_err}"))
+            # -----------------------------------------
+
             message_queue.put(("success", "文本已从 StringScripts 文件夹导入到游戏中。"))
             message_queue.put(("status", "文本导入完成"))
             message_queue.put(("done", None))


### PR DESCRIPTION
## Summary

直接解析 `RPG_RT.lmt` 的 LCF 二進位格式，在 RPGRewriter 匯出/匯入後
自動處理地圖名稱，無需額外手動步驟。

- **匯出**：將地圖名稱寫入 `StringScripts/RM2K_MapNames.txt`（UTF-8），
  供翻譯者編輯後匯入。
- **匯入**：將翻譯後的地圖名稱寫回 `RPG_RT.lmt`，自動備份原始檔為 `.bak`。
- **自動偵測來源編碼**：從 LMT 地圖名稱位元組取樣，選出替換字元最少的
  編碼（支援 cp932 / gbk / big5 / cp1252 / utf-8），避免日文或中文遊戲
  地圖名稱亂碼。

**翻譯地圖名稱的必要性**：RPG Maker 2000/2003 的傳送技能會在選單中
直接顯示地圖名稱。若不翻譯，玩家在使用傳送時無法辨識目的地。

## Test plan

- [ ] 對日文 RM2000 遊戲執行匯出，確認 `StringScripts/RM2K_MapNames.txt`
      內容為正確的日文地圖名稱（不亂碼）
- [ ] 對繁體中文 RM2003 遊戲執行匯出，確認自動偵測到 big5 編碼
- [ ] 編輯 `RM2K_MapNames.txt` 後執行匯入，確認 `RPG_RT.lmt` 更新且遊戲
      傳送選單顯示翻譯後名稱
- [ ] 確認 `RPG_RT.lmt.bak` 備份正確產生

## 由 Sourcery 提供的摘要

新增支持通过 RPG_RT.lmt 导出和重新导入 RPG Maker 2000/2003 的地图名称，从而可以与其他文本一同进行翻译。

新功能：
- 在导出过程中，将 RM2K/RM2K3 的地图名称从 RPG_RT.lmt 导出为 UTF-8 编码的 StringScripts/RM2K_MapNames.txt 文件。
- 在导入过程中，从 StringScripts/RM2K_MapNames.txt 将已翻译的 RM2K/RM2K3 地图名称重新导入到 RPG_RT.lmt 中，并自动创建 .bak 备份。
- 自动检测 RPG_RT.lmt 中 RM2K/RM2K3 地图名称的源编码，以尽量减少日文和中文游戏中出现乱码（mojibake）的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for exporting and re-importing RPG Maker 2000/2003 map names via RPG_RT.lmt so they can be translated alongside other strings.

New Features:
- Export RM2K/RM2K3 map names from RPG_RT.lmt into a UTF-8 StringScripts/RM2K_MapNames.txt file during the export process.
- Import translated RM2K/RM2K3 map names from StringScripts/RM2K_MapNames.txt back into RPG_RT.lmt with automatic .bak backup during the import process.
- Automatically detect the source encoding of RM2K/RM2K3 map names in RPG_RT.lmt to minimise mojibake for Japanese and Chinese games.

</details>